### PR TITLE
giving some time for OS to initialize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.swo
+*.swp
 # Cache objects
 packer_cache/
 

--- a/base/baseAMI.json
+++ b/base/baseAMI.json
@@ -36,6 +36,14 @@
   "provisioners": [
     {
       "type": "shell",
+      "inline": [
+        "sleep 30",
+        "uname -a",
+        "uptime"
+      ]
+    },
+    {
+      "type": "shell",
       "script": "baseInit.sh"
     },
     {


### PR DESCRIPTION
- adding sleep for 30 seconds to let OS boot correctly. this is mentioned in the first `note` in `packer` docs: https://www.packer.io/intro/getting-started/provision.html 