### PR TITLE
Updates files to replace nameserver values to 8.8.8.8 and 8.8.4.4

### DIFF
--- a/exec/execAMI.json
+++ b/exec/execAMI.json
@@ -48,6 +48,10 @@
     },
     {
       "type": "shell",
+      "script": "patchNameServer.sh"
+    },
+    {
+      "type": "shell",
       "script": "execPull.sh",
       "environment_vars": [
         "REL_VER={{user `REL_VER`}}",

--- a/exec/execAMITmp.json
+++ b/exec/execAMITmp.json
@@ -52,6 +52,10 @@
     },
     {
       "type": "shell",
+      "script": "patchNameServer.sh"
+    },
+    {
+      "type": "shell",
       "script": "execPull.sh",
       "environment_vars": [
         "REL_VER={{user `REL_VER`}}",

--- a/exec/patchNameServer.sh
+++ b/exec/patchNameServer.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+set -o pipefail
+
+patch_name_server() {
+  sudo sh -c "echo 'supersede domain-name-servers 8.8.8.8, 8.8.4.4;' >> /etc/dhcp/dhclient.conf"
+}
+
+main() {
+  patch_name_server
+}
+
+main


### PR DESCRIPTION
https://github.com/Shippable/buildami/issues/170
From AWS Documentation
```
To configure an EC2 instance running Ubuntu or Debian Linux to use static DNS server entries, use a text editor such as vim to edit the file /etc/dhcp/dhclient.conf and add the following line to the end of the file:
     supersede domain-name-servers xxx.xxx.xxx.xxx, xxx.xxx.xxx.xxx;
Where xxx.xxx.xxx.xxx is the IP address of a DNS server that you want the EC2 instance to use.
```
https://aws.amazon.com/premiumsupport/knowledge-center/ec2-static-dns-ubuntu-debian/