### PR TITLE
increase block device size while building AMI

### DIFF
--- a/base/baseAMI.json
+++ b/base/baseAMI.json
@@ -30,7 +30,7 @@
         {
           "device_name": "/dev/sda1",
           "volume_type": "io1",
-          "volume_size": "120",
+          "volume_size": "150",
           "iops": "6000",
           "delete_on_termination": true
         }


### PR DESCRIPTION
https://github.com/Shippable/buildami/issues/230

RC buildami is failing  due to lack of space 
https://app.shippable.com/github/Shippable/jobs/build_baseami/builds/5a2e3bebb9ead1070038f249/console

increase block device size to fix the issue
