### PR TITLE
adds pipeline job to patch ami v6.1.4

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -379,6 +379,30 @@ jobs:
     on_failure:
       - script: cat /build/IN/prepami_repo/gitRepo/exec/output.txt
 
+  - name: v614_update
+    type: runSh
+    dependencyMode: strict
+    triggerMode: parallel
+    steps:
+      - IN: prepami_repo
+        switch: off
+      - IN: prod_release
+        switch: off
+      - IN: baseami_params
+        switch: off
+      - IN: ami_bits_access
+        switch: off
+      - IN: genexec_tag_push
+      - IN: gh_ship_repos_tag_push
+      - TASK:
+          script:
+            - pushd $(shipctl get_resource_state "prepami_repo")
+            - cd exec
+            - ./execPackTmp.sh v614_update prod_release ami-9798abed v614 Ubuntu_14.04_Docker_17.06.sh true ami_bits_access
+            - popd
+    on_failure:
+      - script: cat /build/IN/prepami_repo/gitRepo/exec/output.txt
+
   - name: stable_update
     type: runSh
     dependencyMode: strict


### PR DESCRIPTION
https://github.com/Shippable/buildami/issues/293

AMI id set according to latest AMI id for `finalami_prep` - 
https://app.shippable.com/github/Shippable/jobs/finalami_prep/dashboard