### PR TITLE
fix  while building final ami

### DIFF
--- a/exec/execPack.sh
+++ b/exec/execPack.sh
@@ -23,8 +23,10 @@ set_context(){
   # get AMI_ID
   export AMI_ID=$(shipctl get_resource_version_name "$RES_BASE_AMI")
 
+  export RES_BASE_AMI_UP=$(echo $RES_BASE_AMI | awk '{print toupper($0)}')
+  export RES_BASE_AMI_PATH=$(eval echo "$"$RES_BASE_AMI_UP"_PATH")
   # getting propertyBag values
-  pushd $(shipctl get_resource_state "$RES_BASE_AMI")
+  pushd $RES_BASE_AMI_PATH
     export RES_IMG_VER_NAME=$(jq -r '.version.propertyBag.RES_IMG_VER_NAME' version.json)
     export RES_IMG_VER_NAME_DASH=$(jq -r '.version.propertyBag.RES_IMG_VER_NAME_DASH' version.json)
     export IMAGE_NAMES_SPACED=$(jq -r '.version.propertyBag.IMAGE_NAMES_SPACED' version.json)


### PR DESCRIPTION
https://github.com/Shippable/pm/issues/9972

we are not pulling tagged drydock language images because the environment variable `IMAGE_NAMES_SPACED` is not getting set correctly in `finalami_prep` job.

this is because we are using `shipctl` to `get_resource_state` which returns <RES_NAME>_STATE variable while `version.json` is present in <RES_NAME>_PATH variable. 

last change was here - https://github.com/Shippable/buildami/commit/64bebee3476297349bcb6ac799c78c5e0d001ad6#diff-8248f06590528ff27b6eec72087896d4R28
