### PR TITLE
finalami_prep - fix for environment variables with spaces

### DIFF
--- a/exec/execAMI.json
+++ b/exec/execAMI.json
@@ -58,7 +58,7 @@
         "SHIPPABLE_NODE_INIT_SCRIPT={{user `SHIPPABLE_NODE_INIT_SCRIPT`}}",
         "IMAGE_NAMES_SPACED={{user `IMAGE_NAMES_SPACED`}}"
       ],
-      "execute_command": "echo 'packer' | sudo -S sh -c {{ .Vars }} {{ .Path }}"
+      "execute_command": "echo 'packer' | sudo -S env {{ .Vars }} {{ .Path }}"
     }
   ]
 }


### PR DESCRIPTION
https://github.com/Shippable/pm/issues/9972

**we introduced a new environment variable which has spaces - $IMAGE_NAMES_SPACED**. as per packer docs, https://www.packer.io/docs/provisioners/shell.html#sudo-example

```
"echo 'packer' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'"
```
The above example won't work if your environment vars contain spaces or single quotes; in these cases try removing the single quotes:
```
"echo 'packer' | sudo -S env {{ .Vars }} {{ .Path }}"
```