### PR TITLE
Uses sed instead of shipctl

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -482,4 +482,4 @@ jobs:
             - ./windowsBasePack.sh windowsbaseami_prep ami_bits_access_cli
             - popd
     on_failure:
-      - script: cat IN/prepami_repo/gitRepo/base/output.txt
+      - script: cat IN/prepami_repo/gitRepo/windowsBase/output.txt

--- a/shippable.yml
+++ b/shippable.yml
@@ -478,7 +478,8 @@ jobs:
           script:
             - pushd $(shipctl get_resource_state "prepami_repo")
             - cd windowsBase
-            - shipctl replace bootstrap_win.txt
+            - sed -i "s/{{%WINRM_USERNAME%}}/$WINRM_USERNAME/g" ./bootstrap_win.txt
+            - sed -i "s/{{%WINRM_PASSWORD%}}/$WINRM_PASSWORD/g" ./bootstrap_win.txt
             - ./windowsBasePack.sh windowsbaseami_prep ami_bits_access_cli
             - popd
     on_failure:

--- a/windowsBase/bootstrap_win.txt
+++ b/windowsBase/bootstrap_win.txt
@@ -1,7 +1,7 @@
 <powershell>
 # Set username and password
-net user $WINRM_USERNAME $WINRM_PASSWORD
-wmic useraccount where "name='$WINRM_USERNAME'" set PasswordExpires=FALSE
+net user {{%WINRM_USERNAME%}} {{%WINRM_PASSWORD%}}
+wmic useraccount where "name='{{%WINRM_USERNAME%}}'" set PasswordExpires=FALSE
 
 # First, make sure WinRM can't be connected to
 netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" new enable=yes action=block


### PR DESCRIPTION
https://github.com/Shippable/buildami/issues/301

shipctl replace uses `envsubst` internally ( https://github.com/Shippable/node/blob/8547cef4a40372ee402fb4f0435b3b56134d6e23/shipctl/x86_64/Ubuntu_16.04/shippable_replace#L15 )

`envsubst` does two things
- $some_var is an exported env, then substitute the respective value
- $some_var is not an exported env, then substitute with empty string.

This is causing the unexpected portions of `bootstrap_win.txt` to be replaced with empty string

```
<powershell>

# Configure UAC to allow privilege elevation in remote shells
$Key = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
$Setting = 'LocalAccountTokenFilterPolicy'

</powershell>
```

becomes

```
<powershell>

# Configure UAC to allow privilege elevation in remote shells
 = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System'
 = 'LocalAccountTokenFilterPolicy'

</powershell>
```
