### PR TITLE
simplifies inline and sample scripts

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -483,4 +483,7 @@ jobs:
             - ./windowsBasePack.sh windowsbaseami_prep ami_bits_access_cli
             - popd
     on_failure:
-      - script: cat IN/prepami_repo/gitRepo/windowsBase/output.txt
+      - script: pushd $(shipctl get_resource_state "prepami_repo")
+      - script: cd windowsBase
+      - script: cat output.txt
+      - script: popd

--- a/windowsBase/sample_script.ps1
+++ b/windowsBase/sample_script.ps1
@@ -1,13 +1,1 @@
-Write-Host "PACKER_BUILD_NAME is an env var Packer automatically sets for you."
-Write-Host "...or you can set it in your builder variables."
-Write-Host "The default for this builder is:" $Env:PACKER_BUILD_NAME
-
-Write-Host "The PowerShell provisioner will automatically escape characters"
-Write-Host "considered special to PowerShell when it encounters them in"
-Write-Host "your environment variables or in the PowerShell elevated"
-Write-Host "username/password fields."
-Write-Host "For example, VAR1 from our config is:" $Env:VAR1
-Write-Host "Likewise, VAR2 is:" $Env:VAR2
-Write-Host "VAR3 is:" $Env:VAR3
-Write-Host "Finally, VAR4 is:" $Env:VAR4
-Write-Host "None of the special characters needed escaping in the template"
+Write-Host "Testing script execution. WELCOME TO $Env:DEVOPS_LIFE_IMPROVER"

--- a/windowsBase/windowsBaseAMI.json
+++ b/windowsBase/windowsBaseAMI.json
@@ -35,10 +35,7 @@
       "type": "powershell",
       "environment_vars": ["DEVOPS_LIFE_IMPROVER=PACKER"],
       "inline": [
-        "Write-Host \"HELLO NEW USER; WELCOME TO $Env:DEVOPS_LIFE_IMPROVER\"",
-        "Write-Host \"You need to use backtick escapes when using\"",
-        "Write-Host \"characters such as DOLLAR`$ directly in a command\"",
-        "Write-Host \"or in your own scripts.\""
+        "Write-Host \"WELCOME TO $Env:DEVOPS_LIFE_IMPROVER\"",
       ]
     },
     {
@@ -47,12 +44,7 @@
     {
       "script": "./sample_script.ps1",
       "type": "powershell",
-      "environment_vars": [
-        "VAR1=A$Dollar",
-        "VAR2=A`Backtick",
-        "VAR3=A'SingleQuote",
-        "VAR4=A\"DoubleQuote"
-      ]
+      "environment_vars": ["DEVOPS_LIFE_IMPROVER=PACKER"]
     }
   ]
 }


### PR DESCRIPTION
https://github.com/Shippable/buildami/issues/301

Changing the `on_failure` block, because when a failure occurs, we seem to read a file that doesn't exist

![image](https://user-images.githubusercontent.com/4211715/36250589-4cac5dda-1264-11e8-9918-e63fe651331c.png)


This is happening for all the existing jobs in `buildami` like `baseami_prep` ( https://app.shippable.com/github/Shippable/jobs/baseami_prep/builds/5a7b118ea6e8350700e08ff0/console ). I guess this is happening due to wrong path being passed. So, changing it to explicitly go into the gitRepo directory using `shipctl` ( just like we do in task )