### PR TITLE
Add sudos

### DIFF
--- a/exec/execPull.sh
+++ b/exec/execPull.sh
@@ -103,12 +103,12 @@ tag_cexec() {
 fetch_reports() {
   local reports_dir="$CEXEC_LOC/bin"
   local reports_tar_file="reports.tar.gz"
-  rm -rf $reports_dir
-  mkdir -p $reports_dir
+  sudo rm -rf $reports_dir
+  sudo mkdir -p $reports_dir
   pushd $reports_dir
-    wget $REPORTS_DOWNLOAD_URL -O $reports_tar_file
-    tar -xf $reports_tar_file
-    rm -rf $reports_tar_file
+    sudo wget $REPORTS_DOWNLOAD_URL -O $reports_tar_file
+    sudo tar -xf $reports_tar_file
+    sudo rm -rf $reports_tar_file
   popd
 }
 


### PR DESCRIPTION
Not sure why, but _every_ command seems to run with sudo. Do not have enough time to investigate this, I'll just run everything with sudo.
https://github.com/Shippable/buildami/issues/312