### PR TITLE
adds missing parts of windowsBasePack.sh

### DIFF
--- a/windowsBase/windowsBasePack.sh
+++ b/windowsBase/windowsBasePack.sh
@@ -44,6 +44,8 @@ build_ami() {
     -var RES_IMG_VER_NAME_DASH=$SHIPPABLE_RELEASE_VERSION \
     -var WINRM_USERNAME=$WINRM_USERNAME \
     -var WINRM_PASSWORD=$WINRM_PASSWORD \
+    -var IMAGE_NAMES_SPACED="${IMAGE_NAMES_SPACED}" \
+    -var RES_IMG_VER_NAME=$SHIPPABLE_RELEASE_VERSION \
     windowsBaseAMI.json
 
   echo "building AMI"
@@ -56,7 +58,20 @@ build_ami() {
     -var RES_IMG_VER_NAME_DASH=$SHIPPABLE_RELEASE_VERSION \
     -var WINRM_USERNAME=$WINRM_USERNAME \
     -var WINRM_PASSWORD=$WINRM_PASSWORD \
+    -var IMAGE_NAMES_SPACED="${IMAGE_NAMES_SPACED}" \
+    -var RES_IMG_VER_NAME=$SHIPPABLE_RELEASE_VERSION \
     windowsBaseAMI.json 2>&1 | tee output.txt
+
+  # this is to get the ami from output
+  echo versionName=$(cat output.txt | awk -F, '$0 ~/artifact,0,id/ {print $6}' \
+    | cut -d':' -f 2) > "$JOB_STATE/$CURR_JOB.env"
+
+  echo "RES_IMG_VER_NAME=$SHIPPABLE_RELEASE_VERSION" >> "$JOB_STATE/$CURR_JOB.env"
+  echo "RES_IMG_VER_NAME_DASH=$SHIPPABLE_RELEASE_VERSION" >> "$JOB_STATE/$CURR_JOB.env"
+  echo "IMAGE_NAMES_SPACED=$IMAGE_NAMES_SPACED" >> "$JOB_STATE/$CURR_JOB.env"
+  echo "SHIPPABLE_NODE_INIT_SCRIPT=$SHIPPABLE_NODE_INIT_SCRIPT" >> "$JOB_STATE/$CURR_JOB.env"
+
+  cat "$JOB_STATE/$CURR_JOB.env"
 }
 
 main() {


### PR DESCRIPTION
https://github.com/Shippable/buildami/issues/308

Currently the windows AMI packaging job fails 
 https://app.shippable.com/github/Shippable/jobs/windowsbaseami_prep/builds/5a9e2aec5241fd1800de8b5e/console

```
1520316790,,ui,say,==> amazon-ebs: Provisioning with powershell script: ./windowsBasePull.ps1
1520316792,,ui,message,    amazon-ebs: #< CLIXML
1520316792,,ui,message,    amazon-ebs: RES_IMG_VER_NAME=
1520316792,,ui,message,    amazon-ebs: <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><S S="Error">You cannot call a method on a null-valued expression._x000D__x000A_</S><S S="Error">At C:\Windows\Temp\script-5a9e2ba2-9ee2-58af-0085-501f70a1c258.ps1:6 char:27_x000D__x000A_</S><S S="Error">+   foreach ($IMAGE_NAME in $env:IMAGE_NAMES_SPACED.Split(" ")) {_x000D__x000A_</S><S S="Error">+                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~_x000D__x000A_</S><S S="Error">    + CategoryInfo          : InvalidOperation: (:) []%!(PACKER_COMMA) ParentContainsErrorRecordException_x000D__x000A_</S><S S="Error">    + FullyQualifiedErrorId : InvokeMethodOnNull_x000D__x000A_</S><S S="Error"> _x000D__x000A_</S></Objs>
```
as we are not passing the user variables in packer as command line argument. So this PR passes the required variables.

This PR also adds the block of code that writes some envs to `$JOB_STATE/$CURR_JOB.env` , just like we do in [basepack.sh](https://github.com/Shippable/buildami/blob/master/base/basePack.sh#L64-L82)