### PR TITLE
make windows AMI public

### DIFF
--- a/windowsBase/windowsBaseAMI.json
+++ b/windowsBase/windowsBaseAMI.json
@@ -18,6 +18,7 @@
       "instance_type": "c4.large",
       "source_ami": "{{user `SOURCE_AMI`}}",
       "ami_name": "windowsbase-ami-{{user `RES_IMG_VER_NAME_DASH`}}-{{isotime \"2006-01-02-1504\"}}",
+      "ami_groups": "all",
       "user_data_file": "./bootstrap_win.txt",
       "communicator": "winrm",
       "winrm_username": "{{ user `WINRM_USERNAME` }}",


### PR DESCRIPTION
https://github.com/Shippable/buildami/issues/319

Followed https://www.packer.io/docs/builders/amazon-ebs.html#ami_groups for making the AMI public.