### PR TITLE
Execute User data for subsequent boots

### DIFF
--- a/windowsBase/bootstrap_win.txt
+++ b/windowsBase/bootstrap_win.txt
@@ -29,4 +29,7 @@ Stop-Service -Name WinRM
 Set-Service -Name WinRM -StartupType Automatic
 netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" new action=allow localip=any remoteip=any
 Start-Service -Name WinRM
+
+# Execute User data for subsequent boots
+C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 –Schedule
 </powershell>


### PR DESCRIPTION
https://github.com/Shippable/buildami/issues/326

Currently, user data that we send via ec2 is not being executed in our custom windows AMI. So, we need to execute

```
C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 –Schedule
```
to enable it to run on every boot.

Reference: https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2launch.html#ec2launch-config