### PR TITLE
moves instance init to inline powershell

### DIFF
--- a/windowsBase/bootstrap_win.txt
+++ b/windowsBase/bootstrap_win.txt
@@ -29,7 +29,4 @@ Stop-Service -Name WinRM
 Set-Service -Name WinRM -StartupType Automatic
 netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" new action=allow localip=any remoteip=any
 Start-Service -Name WinRM
-
-# Execute User data for subsequent boots
-C:\ProgramData\Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 –Schedule
 </powershell>

--- a/windowsBase/windowsBaseAMI.json
+++ b/windowsBase/windowsBaseAMI.json
@@ -54,6 +54,12 @@
         "RES_IMG_VER_NAME={{user `RES_IMG_VER_NAME`}}",
         "IMAGE_NAMES_SPACED={{user `IMAGE_NAMES_SPACED`}}"
       ]
+    },
+    {
+      "type": "powershell",
+      "inline": [
+        "C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\InitializeInstance.ps1 –Schedule"
+      ]
     }
   ]
 }


### PR DESCRIPTION
https://github.com/Shippable/buildami/issues/326

Windows AMI started failing from https://app.shippable.com/github/Shippable/jobs/windowsbaseami_prep/builds/5aa26dc6ec373f1700486137/console 

The only change done was an addition of a command to the user data script. Moving this script to packer config file, to see if the problem is because of it.