### PR TITLE
replaces hyphen in windowsBaseAMI powershell command

### DIFF
--- a/windowsBase/windowsBaseAMI.json
+++ b/windowsBase/windowsBaseAMI.json
@@ -58,7 +58,7 @@
     {
       "type": "powershell",
       "inline": [
-        "C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\InitializeInstance.ps1 –Schedule"
+        "C:\\ProgramData\\Amazon\\EC2-Windows\\Launch\\Scripts\\InitializeInstance.ps1 -Schedule"
       ]
     }
   ]


### PR DESCRIPTION
https://github.com/Shippable/buildami/issues/326

Seeing the following error in Windows AMI building.

```
#< CLIXML
1520831369,,ui,message,    amazon-ebs: <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><S S="Error">At C:\Windows\Temp\script-5aa60361-146c-6ea9-f7ff-c6a00993f5c7.ps1:1 char:75_x000D__x000A_</S><S S="Error">+ ... \Amazon\EC2-Windows\Launch\Scripts\InitializeInstance.ps1 â€“Schedule_x000D__x000A_</S><S S="Error">+                                                                 ~~~~~~~~~_x000D__x000A_</S><S S="Error">The string is missing the terminator: "._x000D__x000A_</S><S S="Error">    + CategoryInfo          : ParserError: (:) []%!(PACKER_COMMA) ParseException_x000D__x000A_</S><S S="Error">    + FullyQualifiedErrorId : TerminatorExpectedAtEndOfString_x000D__x000A_</S><S S="Error"> _x000D__x000A_</S></Objs>
```