### PR TITLE
correct the reqproc IN to c7 patch

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -678,7 +678,7 @@ jobs:
         switch: off
       - IN: cexec_repo
       - IN: node_repo
-      - IN: reqProc_x86_64_CentOS_7_prep
+      - IN: reqProc_x86_64_Ubuntu_16_04_prep
       - IN: ami_reqKick_repo
       - IN: c7baseami_prep
       - TASK:


### PR DESCRIPTION
#349 

c7 still uses a u16 reqproc, so there is no c7 version of the reqproc job.