### PR TITLE
Add config to prevent IPv4 forwading getting disabled

### DIFF
--- a/gcp/templates/prep/99-shippable.conf
+++ b/gcp/templates/prep/99-shippable.conf
@@ -1,0 +1,4 @@
+# GCE by default disables packet forwading between network interfaces.
+# Docker enables this when it starts up, but it can get reset at any time
+# if the configs are reset. This will prevent it from getting reset.
+net.ipv4.ip_forward = 1

--- a/gcp/templates/prep/copyConfigs.sh
+++ b/gcp/templates/prep/copyConfigs.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+echo "Copying 99-shippable.conf..."
+sudo cp /tmp/99-shippable.conf /etc/sysctl.d/99-shippable.conf

--- a/gcp/templates/prep/packer.json
+++ b/gcp/templates/prep/packer.json
@@ -43,6 +43,15 @@
       ]
     },
     {
+      "destination": "/tmp/99-shippable.conf",
+      "source": "99-shippable.conf",
+      "type": "file"
+    },
+    {
+      "type": "shell",
+      "script": "copyConfigs.sh"
+    },
+    {
       "type": "shell",
       "script": "init.sh",
       "environment_vars": [


### PR DESCRIPTION
https://github.com/Shippable/buildami/issues/574

I haven't copied to file directly as it's unlikely to work without sudo. [From the docs](https://www.packer.io/docs/provisioners/file.html):
>The recommended usage of the file provisioner is to use it to upload files, and then use shell provisioner to move them to the proper place, set permissions, etc.

I have **not** tested the Packer script, I'll use the pipeline to see if this works. I have tested the config however and it works.