### PR TITLE
Build on top of previous image

### DIFF
--- a/images/x86_64/CentOS_7/shippable.yml
+++ b/images/x86_64/CentOS_7/shippable.yml
@@ -12,7 +12,7 @@ final_task_template: &final_task_template
       export ARCHITECTURE=$(shipctl get_resource_version_key "$BASE_IMG_RES" "ARCHITECTURE")
       export OS=$(shipctl get_resource_version_key "$BASE_IMG_RES" "OS")
       export DOCKER_VER=$(shipctl get_resource_version_key "$BASE_IMG_RES" "DOCKER_VER")
-      export SOURCE_IMAGE_FAMILY=$(shipctl get_resource_version_key "$BASE_IMG_RES" "IMAGE_FAM_NAME")
+      # export SOURCE_IMAGE_FAMILY=$(shipctl get_resource_version_key "$BASE_IMG_RES" "IMAGE_FAM_NAME")
   - |
       REQPROC_REG=$(shipctl get_resource_version_key "$REQPROC_IMG_RES" "sourceName")
       REQPROC_TAG=$(shipctl get_resource_version_key "$REQPROC_RES" "versionName")

--- a/images/x86_64/Ubuntu_14.04/shippable.yml
+++ b/images/x86_64/Ubuntu_14.04/shippable.yml
@@ -12,7 +12,7 @@ final_task_template: &final_task_template
       export ARCHITECTURE=$(shipctl get_resource_version_key "$BASE_IMG_RES" "ARCHITECTURE")
       export OS=$(shipctl get_resource_version_key "$BASE_IMG_RES" "OS")
       export DOCKER_VER=$(shipctl get_resource_version_key "$BASE_IMG_RES" "DOCKER_VER")
-      export SOURCE_IMAGE_FAMILY=$(shipctl get_resource_version_key "$BASE_IMG_RES" "IMAGE_FAM_NAME")
+      # export SOURCE_IMAGE_FAMILY=$(shipctl get_resource_version_key "$BASE_IMG_RES" "IMAGE_FAM_NAME")
   - |
       REQPROC_REG=$(shipctl get_resource_version_key "$REQPROC_IMG_RES" "sourceName")
       REQPROC_TAG=$(shipctl get_resource_version_key "$REQPROC_RES" "versionName")

--- a/images/x86_64/Ubuntu_16.04/shippable.yml
+++ b/images/x86_64/Ubuntu_16.04/shippable.yml
@@ -12,7 +12,7 @@ final_task_template: &final_task_template
       export ARCHITECTURE=$(shipctl get_resource_version_key "$BASE_IMG_RES" "ARCHITECTURE")
       export OS=$(shipctl get_resource_version_key "$BASE_IMG_RES" "OS")
       export DOCKER_VER=$(shipctl get_resource_version_key "$BASE_IMG_RES" "DOCKER_VER")
-      export SOURCE_IMAGE_FAMILY=$(shipctl get_resource_version_key "$BASE_IMG_RES" "IMAGE_FAM_NAME")
+      # export SOURCE_IMAGE_FAMILY=$(shipctl get_resource_version_key "$BASE_IMG_RES" "IMAGE_FAM_NAME")
   - |
       REQPROC_REG=$(shipctl get_resource_version_key "$REQPROC_IMG_RES" "sourceName")
       REQPROC_TAG=$(shipctl get_resource_version_key "$REQPROC_RES" "versionName")


### PR DESCRIPTION
We rebuilt everything from the base image so that it gets the correct kernel versions and any other changes. Now, we can go back to using the built image to speed up final builds as before.

https://github.com/Shippable/buildami/issues/587