### PR TITLE
add update jobs for the aws amis v664

### DIFF
--- a/images/x86_64/CentOS_7/shippable.yml
+++ b/images/x86_64/CentOS_7/shippable.yml
@@ -1,6 +1,6 @@
-# 
+#
 # Templates
-# 
+#
 final_task_setup_template: &final_task_setup_template
   - set -o pipefail
   - |
@@ -54,9 +54,9 @@ final_on_success_template: &final_on_success_template
 
 final_on_failure_template: &final_on_failure_template
   - cat output.txt
-# 
+#
 # Resources
-# 
+#
 resources:
   - name: c7baseami_params
     type: params
@@ -1245,6 +1245,37 @@ jobs:
             - pushd $(shipctl get_resource_state "buildami_repo")
             - cd c7Exec
             - ./execPackUpdate.sh c7_v654_update prod_release ami-09631c76 v654 ami_bits_access
+            - popd
+    on_failure:
+      - script: cat /build/IN/buildami_repo/gitRepo/c7Exec/output.txt
+
+  - name: c7_v664_update
+    type: runSh
+    dependencyMode: strict
+    triggerMode: parallel
+    steps:
+      - IN: buildami_repo
+        switch: off
+      - IN: prod_release
+        switch: off
+      - IN: baseami_params
+        switch: off
+      - IN: ami_bits_access
+        switch: off
+      - IN: execTemplates_repo_file_tag
+      - IN: node_repo_file_tag
+      - IN: cexec_repo_file_tag
+      - IN: reqExec_repo_tag
+      - IN: reqProc_repo_tag
+      - IN: c7repLib_x8664_tag
+      - IN: u14repLib_x8664_tag
+      - IN: u16repLib_x8664_tag
+      - IN: u16repLib_aarch64_tag
+      - TASK:
+          script:
+            - pushd $(shipctl get_resource_state "buildami_repo")
+            - cd c7Exec
+            - ./execPackUpdate.sh c7_v664_update prod_release ami-4a1d3035 v664 ami_bits_access
             - popd
     on_failure:
       - script: cat /build/IN/buildami_repo/gitRepo/c7Exec/output.txt

--- a/images/x86_64/Ubuntu_14.04/shippable.yml
+++ b/images/x86_64/Ubuntu_14.04/shippable.yml
@@ -1,6 +1,6 @@
-# 
+#
 # Templates
-# 
+#
 final_task_setup_template: &final_task_setup_template
   - set -o pipefail
   - |
@@ -3038,6 +3038,37 @@ jobs:
             - pushd $(shipctl get_resource_state "buildami_repo")
             - cd exec
             - ./execPackUpdate.sh v654_update prod_release ami-d23749ad v654 ami_bits_access
+            - popd
+    on_failure:
+      - script: cat /build/IN/buildami_repo/gitRepo/exec/output.txt
+
+  - name: v664_update
+    type: runSh
+    dependencyMode: strict
+    triggerMode: parallel
+    steps:
+      - IN: buildami_repo
+        switch: off
+      - IN: prod_release
+        switch: off
+      - IN: baseami_params
+        switch: off
+      - IN: ami_bits_access
+        switch: off
+      - IN: execTemplates_repo_file_tag
+      - IN: node_repo_file_tag
+      - IN: cexec_repo_file_tag
+      - IN: reqExec_repo_tag
+      - IN: reqProc_repo_tag
+      - IN: c7repLib_x8664_tag
+      - IN: u14repLib_x8664_tag
+      - IN: u16repLib_x8664_tag
+      - IN: u16repLib_aarch64_tag
+      - TASK:
+          script:
+            - pushd $(shipctl get_resource_state "buildami_repo")
+            - cd exec
+            - ./execPackUpdate.sh v664_update prod_release ami-0a032e75 v664 ami_bits_access
             - popd
     on_failure:
       - script: cat /build/IN/buildami_repo/gitRepo/exec/output.txt

--- a/images/x86_64/Ubuntu_16.04/shippable.yml
+++ b/images/x86_64/Ubuntu_16.04/shippable.yml
@@ -1,6 +1,6 @@
-# 
+#
 # Templates
-# 
+#
 final_task_setup_template: &final_task_setup_template
   - set -o pipefail
   - |
@@ -55,9 +55,9 @@ final_on_success_template: &final_on_success_template
 final_on_failure_template: &final_on_failure_template
   - cat output.txt
 
-# 
+#
 # Resources
-# 
+#
 resources:
   - name: u16microbase_dd_repo
     type: gitRepo
@@ -1889,6 +1889,37 @@ jobs:
             - pushd $(shipctl get_resource_state "buildami_repo")
             - cd u16Exec
             - ./execPackUpdate.sh u16_v654_update prod_release ami-c5c9b5ba v654 ami_bits_access
+            - popd
+    on_failure:
+      - script: cat /build/IN/buildami_repo/gitRepo/u16Exec/output.txt
+
+  - name: u16_v664_update
+    type: runSh
+    dependencyMode: strict
+    triggerMode: parallel
+    steps:
+      - IN: buildami_repo
+        switch: off
+      - IN: prod_release
+        switch: off
+      - IN: baseami_params
+        switch: off
+      - IN: ami_bits_access
+        switch: off
+      - IN: execTemplates_repo_file_tag
+      - IN: node_repo_file_tag
+      - IN: cexec_repo_file_tag
+      - IN: reqExec_repo_tag
+      - IN: reqProc_repo_tag
+      - IN: c7repLib_x8664_tag
+      - IN: u14repLib_x8664_tag
+      - IN: u16repLib_x8664_tag
+      - IN: u16repLib_aarch64_tag
+      - TASK:
+          script:
+            - pushd $(shipctl get_resource_state "buildami_repo")
+            - cd u16Exec
+            - ./execPackUpdate.sh u16_v664_update prod_release ami-951c31ea v664 ami_bits_access
             - popd
     on_failure:
       - script: cat /build/IN/buildami_repo/gitRepo/u16Exec/output.txt


### PR DESCRIPTION
AMI-ids taken from latest runs of prod "finalami_prep" jobs for u14, u16, and c7.

windows AMIs are being manually created, so that update job is not present.