### PR TITLE
Add jobs to update images

### DIFF
--- a/updateImages/adapter.sh
+++ b/updateImages/adapter.sh
@@ -1,0 +1,44 @@
+# Source this where required.
+RESPONSE_FILE=/tmp/response
+
+request() {
+  REQUEST_TYPE="$1"
+  URL="$2"
+  AUTHORIZATION_HEADER="$3"
+  DATA="$4"
+
+  {
+    RESPONSE_CODE=$(curl \
+      -H "Content-Type: application/json" \
+      -H "Authorization: $AUTHORIZATION_HEADER" \
+      -X "$REQUEST_TYPE" "$URL" \
+      -d "$DATA" \
+      --silent \
+      --write-out "%{http_code}\n" \
+      --output $RESPONSE_FILE \
+    )
+  } || {
+    ERROR=$(echo $?)
+  }
+  RESPONSE=$(cat $RESPONSE_FILE)
+  rm $RESPONSE_FILE
+}
+
+# get <url> <authorization>"
+get() {
+  echo "GET $1"
+  request "GET" "$1" "$2"
+}
+
+# put <url> <authorization> <body>
+put() {
+  echo "PUT $1"
+  request "PUT" "$1" "$2" "$3"
+}
+
+response_error() {
+  echo "|__ Failure"
+  echo "    |__ Status Code: $RESPONSE_CODE"
+  echo "    |__ Response: $RESPONSE"
+  exit 1
+}

--- a/updateImages/production.csv
+++ b/updateImages/production.csv
@@ -1,0 +1,45 @@
+system_machine_image_name,builder_resource_name,prefix
+Google Cloud - Ubuntu 14.04 - v6.6.4,v664_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v6.5.4,v654_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v6.4.4,v644_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v6.3.4,v634_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v6.2.4,v624_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v6.1.4,v614_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v5.10.4,v5104_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v5.8.2,v582_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v5.7.3,v573_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v5.6.1,v561_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v5.5.1,v551_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v5.4.1,v541_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v5.3.2,v532_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 16.04 - v6.6.4,v664_u16_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 16.04 - v6.5.4,v654_u16_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 16.04 - v6.4.4,v644_u16_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 16.04 - v6.3.4,v634_u16_x8664_gce_img,ship-bits/
+Google Cloud - CentOS 7 - v6.6.4,v664_c7_x8664_gce_img,ship-bits/
+Google Cloud - CentOS 7 - v6.5.4,v654_c7_x8664_gce_img,ship-bits/
+Google Cloud - CentOS 7 - v6.4.4,v644_c7_x8664_gce_img,ship-bits/
+Google Cloud - CentOS 7 - v6.3.4,v634_c7_x8664_gce_img,ship-bits/
+AWS - Ubuntu 14.04 - v6.6.4,v664_update,
+AWS - Ubuntu 14.04 - v6.5.4,v654_update,
+AWS - Ubuntu 14.04 - v6.4.4,v644_update,
+AWS - Ubuntu 14.04 - v6.3.4,v634_update,
+AWS - Ubuntu 14.04 - v6.2.4,v624_update,
+AWS - Ubuntu 14.04 - v6.1.4,v614_update,
+AWS - Ubuntu 14.04 - v5.10.4,v5104_update,
+AWS - Ubuntu 14.04 - v5.8.2,v582_update,
+AWS - Ubuntu 14.04 - v5.7.3,v573_update,
+AWS - Ubuntu 14.04 - v5.6.1,v561_update,
+AWS - Ubuntu 14.04 - v5.5.1,v551_update,
+AWS - Ubuntu 14.04 - v5.4.1,v541_update,
+AWS - Ubuntu 14.04 - v5.3.2,v532_update,
+AWS - Ubuntu 14.04 - Stable,stable_update,
+AWS - Ubuntu 14.04 - Unstable,unstable_update,
+AWS - Ubuntu 16.04 - v6.6.4,u16_v664_update,
+AWS - Ubuntu 16.04 - v6.5.4,u16_v654_update,
+AWS - Ubuntu 16.04 - v6.4.4,u16_v644_update,
+AWS - Ubuntu 16.04 - v6.3.4,u16_v634_update,
+AWS - CentOS 7 - v6.6.4,c7_v664_update,
+AWS - CentOS 7 - v6.5.4,c7_v654_update,
+AWS - CentOS 7 - v6.4.4,c7_v644_update,
+AWS - CentOS 7 - v6.3.4,c7_v634_update,

--- a/updateImages/rc.csv
+++ b/updateImages/rc.csv
@@ -1,0 +1,46 @@
+system_machine_image_name,builder_resource_name,prefix
+Google Cloud - Ubuntu 14.04 - Master,patch_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v6.6.4,v664_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v6.5.4,v654_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v6.4.4,v644_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v6.3.4,v634_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v6.2.4,v624_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v6.1.4,v614_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v5.10.4,v5104_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v5.8.2,v582_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v5.7.3,v573_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v5.6.1,v561_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v5.5.1,v551_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v5.4.1,v541_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v5.3.2,v532_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 16.04 - Master,patch_u16_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 16.04 - v6.6.4,v664_u16_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 16.04 - v6.5.4,v654_u16_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 16.04 - v6.4.4,v644_u16_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 16.04 - v6.3.4,v634_u16_x8664_gce_img,ship-bits/
+Google Cloud - CentOS 7 - Master,patch_c7_x8664_gce_img,ship-bits/
+Google Cloud - CentOS 7 - v6.6.4,v664_c7_x8664_gce_img,ship-bits/
+Google Cloud - CentOS 7 - v6.5.4,v654_c7_x8664_gce_img,ship-bits/
+Google Cloud - CentOS 7 - v6.4.4,v644_c7_x8664_gce_img,ship-bits/
+Google Cloud - CentOS 7 - v6.3.4,v634_c7_x8664_gce_img,ship-bits/
+AWS - Ubuntu 14.04 - v6.6.4,v664_update,
+AWS - Ubuntu 14.04 - v6.5.4,v654_update,
+AWS - Ubuntu 14.04 - v6.4.4,v644_update,
+AWS - Ubuntu 14.04 - v6.3.4,v634_update,
+AWS - Ubuntu 14.04 - v6.2.4,v624_update,
+AWS - Ubuntu 14.04 - v6.1.4,v614_update,
+AWS - Ubuntu 14.04 - v5.10.4,v5104_update,
+AWS - Ubuntu 14.04 - v5.8.2,v582_update,
+AWS - Ubuntu 14.04 - v5.7.3,v573_update,
+AWS - Ubuntu 14.04 - v5.6.1,v561_update,
+AWS - Ubuntu 14.04 - v5.5.1,v551_update,
+AWS - Ubuntu 14.04 - v5.4.1,v541_update,
+AWS - Ubuntu 14.04 - v5.3.2,v532_update,
+AWS - Ubuntu 16.04 - v6.6.4,u16_v664_update,
+AWS - Ubuntu 16.04 - v6.5.4,u16_v654_update,
+AWS - Ubuntu 16.04 - v6.4.4,u16_v644_update,
+AWS - Ubuntu 16.04 - v6.3.4,u16_v634_update,
+AWS - CentOS 7 - v6.6.4,c7_v664_update,
+AWS - CentOS 7 - v6.5.4,c7_v654_update,
+AWS - CentOS 7 - v6.4.4,c7_v644_update,
+AWS - CentOS 7 - v6.3.4,c7_v634_update,

--- a/updateImages/shippable.yml
+++ b/updateImages/shippable.yml
@@ -1,0 +1,41 @@
+resources:
+  - name: shippable_api_token_kv
+    type: integration
+    integration: shippable_api_token_kv
+
+jobs:
+  - name: rc_setup_system_machine_images
+    type: runSh
+    steps:
+      - IN: buildami_repo
+        switch: off
+      - IN: shippable_api_token_kv
+        switch: off
+      - TASK:
+          script:
+            - apt-get install bsdmainutils
+            - cd $(shipctl get_resource_state buildami_repo)/updateImages
+            - export SOURCE_API_URL="https://api.shippable.com"
+            - export SOURCE_API_TOKEN="$PRODUCTION_API_TOKEN"
+            - export TARGET_API_URL="https://rcapi.shippable.com"
+            - export TARGET_API_TOKEN="$RC_API_TOKEN"
+            - export CONFIG_CSV_PATH="rc.csv"
+            - ./update_images.sh
+
+  - name: production_setup_system_machine_images
+    type: runSh
+    steps:
+      - IN: buildami_repo
+        switch: off
+      - IN: shippable_api_token_kv
+        switch: off
+      - TASK:
+          script:
+            - apt-get install bsdmainutils
+            - cd $(shipctl get_resource_state buildami_repo)/updateImages
+            - export SOURCE_API_URL="https://api.shippable.com"
+            - export SOURCE_API_TOKEN="$PRODUCTION_API_TOKEN"
+            - export TARGET_API_URL="https://api.shippable.com"
+            - export TARGET_API_TOKEN="$PRODUCTION_API_TOKEN"
+            - export CONFIG_CSV_PATH="production.csv"
+            - ./update_images.sh

--- a/updateImages/update_images.sh
+++ b/updateImages/update_images.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -e
+
+source adapter.sh
+
+check_input() {
+  if [ -z "$SOURCE_API_URL" ]; then echo "Missing environment variable: SOURCE_API_URL"; exit 1; fi
+  if [ -z "$SOURCE_API_TOKEN" ]; then echo "Missing environment variable: SOURCE_API_TOKEN"; exit 1; fi
+  if [ -z "$TARGET_API_URL" ]; then echo "Missing environment variable: TARGET_API_URL"; exit 1; fi
+  if [ -z "$TARGET_API_TOKEN" ]; then echo "Missing environment variable: TARGET_API_TOKEN"; exit 1; fi
+  if [ -z "$CONFIG_CSV_PATH" ]; then echo "Missing environment variable: CONFIG_CSV_PATH"; exit 1; fi
+  if [ "$PLAN_ONLY" != false ]; then PLAN_ONLY=true; fi
+}
+
+update_system_machine_image_versions() {
+  PLAN="System Machine Image Name, System Machine Image ID, Builder Resource Name, Latest Image"
+
+  get "$TARGET_API_URL"/systemMachineImages "$TARGET_API_TOKEN"
+  if [ "$RESPONSE_CODE" != 200 ]; then response_error; fi
+  SYSTEM_MACHINE_IMAGES="$RESPONSE"
+
+  IFS=$'\n'
+  for system_machine_image in $(cat "$CONFIG_CSV_PATH" | tail -n +2); do
+    system_machine_image_name="$(echo $system_machine_image | cut -d "," -f 1)"
+    builder_resource_name="$(echo $system_machine_image | cut -d "," -f 2)"
+    image_prefix="$(echo $system_machine_image | cut -d "," -f 3)"
+
+    # Get the image builder resource id.
+    get "$SOURCE_API_URL"/resources?names="$builder_resource_name" "$SOURCE_API_TOKEN"
+    if [ "$RESPONSE_CODE" != 200 ]; then response_error; fi
+    builder_resource_id=$(echo "$RESPONSE" | jq ".[0].id")
+
+    # Get the image builder resource version
+    get "$SOURCE_API_URL""/versions?resourceIds=""$builder_resource_id""&limit=1&sortBy=createdAt&sortOrder=-1" "$SOURCE_API_TOKEN"
+    if [ "$RESPONSE_CODE" != 200 ]; then response_error; fi
+    version_name=$(echo "$RESPONSE" | jq -r ".[0].versionName")
+
+    # Find the system machine image ID
+    system_machine_image_id=$(echo "$SYSTEM_MACHINE_IMAGES" | jq -r ".[] | select (.name == \"$system_machine_image_name\") | .id")
+
+    if [ "$PLAN_ONLY" == false ]; then
+      put "$TARGET_API_URL""/systemMachineImages/""$system_machine_image_id" "$TARGET_API_TOKEN" "{ \"externalId\": \"$image_prefix$version_name\" }"
+      if [ "$RESPONSE_CODE" != 200 ]; then response_error; fi
+      echo "Updated $system_machine_image_name -> $(echo "$RESPONSE" | jq -r ".externalId")"
+    else
+      PLAN="$PLAN\n$system_machine_image_name, $system_machine_image_id, $builder_resource_name, $image_prefix$version_name"
+    fi
+  done
+
+  if [ "$PLAN_ONLY" == true ]; then
+    echo -e $PLAN | column -s "," -t
+  fi
+}
+
+check_input
+update_system_machine_image_versions


### PR DESCRIPTION
Notes:
1. I have not added Windows images as some of them are manual. The lists can be extended to add them or any other images.
1. By default, only "plan" will run. `PLAN_ONLY: false` needs to be passed explicitly to update the images.