### PR TITLE
remove docker before re installing it

### DIFF
--- a/gcp/x86_64/CentOS_7/final/codeRefresh.sh
+++ b/gcp/x86_64/CentOS_7/final/codeRefresh.sh
@@ -97,6 +97,8 @@ trap before_exit EXIT
 check_envs
 fetch_node_scripts
 
+yum remove -y docker docker-common docker-selinux docker-engine
+rm -rf /etc/docker/
+
 __process_msg "Initializing node"
 source "$NODE_SCRIPTS_LOCATION/initScripts/$NODE_ARCHITECTURE/$NODE_OPERATING_SYSTEM/$INIT_SCRIPT_NAME"
-


### PR DESCRIPTION
docker doesn't downgrade in centos. so we will have to remove it before re installing it. This is a one time thing. I will remove this code once the images get built.

https://github.com/Shippable/pm/issues/11542