### PR TITLE
install rng-tools

### DIFF
--- a/gcp/templates/final/packer.json
+++ b/gcp/templates/final/packer.json
@@ -47,6 +47,11 @@
     },
     {
       "type": "shell",
+      "script": "additionalPackages.sh",
+      "execute_command": "echo 'packer' | sudo -S env {{ .Vars }} {{ .Path }}"
+    },
+    {
+      "type": "shell",
       "script": "codeRefresh.sh",
       "environment_vars": [
         "ARCHITECTURE={{user `ARCHITECTURE`}}",

--- a/gcp/x86_64/Ubuntu_16.04/final/additionalPackages.sh
+++ b/gcp/x86_64/Ubuntu_16.04/final/additionalPackages.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -e
+set -e
+set -o pipefail
+
+__process_marker() {
+  local prompt="$@"
+  echo ""
+  echo "# $(date +"%T") #######################################"
+  echo "# $prompt"
+  echo "##################################################"
+}
+
+__process_msg() {
+  local message="$@"
+  echo "|___ $@"
+}
+
+before_exit() {
+  ## flush any remaining console
+  echo $1
+  echo $2
+  __process_msg "Additional packages script completed"
+}
+
+install_rngtools() {
+  __process_msg "installing rng-tools for entropy"
+  apt-get install -y rng-tools=5-0ubuntu3
+}
+
+__process_marker "installing additional packages"
+trap before_exit EXIT
+install_rngtools


### PR DESCRIPTION
#669

adds new script to install rng-tools for u16 gcp machines in the "final" ami jobs.