### PR TITLE
rearrange script order u16 gcp final

### DIFF
--- a/gcp/templates/final/packer.json
+++ b/gcp/templates/final/packer.json
@@ -47,11 +47,6 @@
     },
     {
       "type": "shell",
-      "script": "additionalPackages.sh",
-      "execute_command": "echo 'packer' | sudo -S env {{ .Vars }} {{ .Path }}"
-    },
-    {
-      "type": "shell",
       "script": "codeRefresh.sh",
       "environment_vars": [
         "ARCHITECTURE={{user `ARCHITECTURE`}}",
@@ -76,6 +71,11 @@
       "environment_vars": [
         "IMG_VER={{user `IMG_VER`}}"
       ]
+    },
+    {
+      "type": "shell",
+      "script": "additionalPackages.sh",
+      "execute_command": "echo 'packer' | sudo -S env {{ .Vars }} {{ .Path }}"
     }
   ]
 }


### PR DESCRIPTION
#669 

background process was preventing apt-get from being able to obtain the lock, so i'm moving the script to the end of the flow, rather than adding sleep.