### PR TITLE
add a new user centos-debug(will be reverted)

### DIFF
--- a/gcp/templates/patch/packer.json
+++ b/gcp/templates/patch/packer.json
@@ -53,7 +53,8 @@
         "REQPROC_IMAGE={{user `REQPROC_IMAGE`}}",
         "REQKICK_DOWNLOAD_URL={{user `REQKICK_DOWNLOAD_URL`}}",
         "CEXEC_DOWNLOAD_URL={{user `CEXEC_DOWNLOAD_URL`}}",
-        "REPORTS_DOWNLOAD_URL={{user `REPORTS_DOWNLOAD_URL`}}"
+        "REPORTS_DOWNLOAD_URL={{user `REPORTS_DOWNLOAD_URL`}}",
+        "SSH_USERNAME={{ user `ssh_username`}}"
       ],
       "execute_command": "echo 'packer' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'"
     }

--- a/gcp/x86_64/CentOS_7/patch/codePull.sh
+++ b/gcp/x86_64/CentOS_7/patch/codePull.sh
@@ -71,5 +71,18 @@ __process_error() {
   echo -e "     $error"
 }
 
+export SSH_DEBUG_USER="centos-debug"
+__add_ssh_user() {
+  sudo useradd $SSH_DEBUG_USER
+  for group in `groups $SSH_USERNAME | cut -d':' -f 2`; do
+    if [ "$group" != "$SSH_USERNAME" ]; then
+      sudo usermod -aG $group $SSH_DEBUG_USER
+    fi
+  done
+}
+
+__process_msg "Adding ssh-user $SSH_DEBUG_USER"
+exec_grp "__add_ssh_user"
+
 __process_msg "Initializing node"
 source "$NODE_SCRIPTS_LOCATION/initScripts/$NODE_ARCHITECTURE/$NODE_OPERATING_SYSTEM/$INIT_SCRIPT_NAME"


### PR DESCRIPTION
https://github.com/Shippable/buildami/issues/672
This is a POC. We will create a new user `centos-debug` and all the required perms to it. The `ssh_username` user which is `centos` in our case, is getting its sudo perms getting stripped at the end of the packer build.

I will be merging this PR myself and revert this later after verification. I have spoken to @rageshkrishna about this.