### PR TITLE
add additionalpackages file for c7 final

### DIFF
--- a/gcp/x86_64/CentOS_7/final/additionalPackages.sh
+++ b/gcp/x86_64/CentOS_7/final/additionalPackages.sh
@@ -24,7 +24,7 @@ before_exit() {
 
 install_rngtools() {
   __process_msg "installing rng-tools for entropy"
-  apt-get install -y rng-tools=4-0ubuntu2.1
+  yum install -y rng-tools-6.3.1-3.el7
 }
 
 __process_marker "installing additional packages"


### PR DESCRIPTION
#681 

also makes the u14 script executable.  The packer script itself does a chmod, so making the script executable is not necessary, but I think it could potentially prevent confusion and errors later on.