### PR TITLE
remove references to specific versions

### DIFF
--- a/gcp/x86_64/CentOS_7/final/additionalPackages.sh
+++ b/gcp/x86_64/CentOS_7/final/additionalPackages.sh
@@ -24,7 +24,7 @@ before_exit() {
 
 install_rngtools() {
   __process_msg "installing rng-tools for entropy"
-  yum install -y rng-tools-6.3.1-3.el7
+  yum install -y rng-tools
 }
 
 __process_marker "installing additional packages"

--- a/gcp/x86_64/CentOS_7/prep/init.sh
+++ b/gcp/x86_64/CentOS_7/prep/init.sh
@@ -75,7 +75,7 @@ __process_msg "installing wget"
 exec_cmd "sudo yum -y install wget"
 
 __process_msg "installing rng-tools"
-exec_cmd "sudo yum -y install rng-tools-6.3.1-3.el7"
+exec_cmd "sudo yum -y install rng-tools"
 
 __process_msg "downloading node scripts tarball"
 exec_cmd "wget '$NODE_DOWNLOAD_URL' -O $NODE_SCRIPTS_TMP_LOC"

--- a/gcp/x86_64/Ubuntu_14.04/final/additionalPackages.sh
+++ b/gcp/x86_64/Ubuntu_14.04/final/additionalPackages.sh
@@ -24,7 +24,7 @@ before_exit() {
 
 install_rngtools() {
   __process_msg "installing rng-tools for entropy"
-  apt-get install -y rng-tools=4-0ubuntu2.1
+  apt-get install -y rng-tools
 }
 
 __process_marker "installing additional packages"

--- a/gcp/x86_64/Ubuntu_14.04/prep/init.sh
+++ b/gcp/x86_64/Ubuntu_14.04/prep/init.sh
@@ -69,7 +69,7 @@ __process_msg "adding dns settings to the node"
 exec_cmd "echo 'supersede domain-name-servers 8.8.8.8, 8.8.4.4;' >> /etc/dhcp/dhclient.conf"
 
 __process_msg "installing rng-tools"
-exec_cmd "apt-get install -y rng-tools=4-0ubuntu2.1"
+exec_cmd "apt-get install -y rng-tools"
 
 __process_msg "creating node scripts dir"
 exec_cmd "mkdir -p $NODE_SCRIPTS_LOCATION"

--- a/gcp/x86_64/Ubuntu_16.04/final/additionalPackages.sh
+++ b/gcp/x86_64/Ubuntu_16.04/final/additionalPackages.sh
@@ -24,7 +24,7 @@ before_exit() {
 
 install_rngtools() {
   __process_msg "installing rng-tools for entropy"
-  apt-get install -y rng-tools=5-0ubuntu3
+  apt-get install -y rng-tools
 }
 
 __process_marker "installing additional packages"

--- a/gcp/x86_64/Ubuntu_16.04/prep/init.sh
+++ b/gcp/x86_64/Ubuntu_16.04/prep/init.sh
@@ -69,7 +69,7 @@ __process_msg "adding dns settings to the node"
 exec_cmd "echo 'supersede domain-name-servers 8.8.8.8, 8.8.4.4;' >> /etc/dhcp/dhclient.conf"
 
 __process_msg "installing rng-tools"
-exec_cmd "apt-get install -y rng-tools=5-0ubuntu3"
+exec_cmd "apt-get install -y rng-tools"
 
 __process_msg "creating node scripts dir"
 exec_cmd "mkdir -p $NODE_SCRIPTS_LOCATION"


### PR DESCRIPTION
#683 

seems that for u16, a lack of apt-get update is preventing the correct version of rng-tools from being recognized.  Moving the install to be after the node-init-script should ensure that an update occurs before the installation is attempted.  This also avoids having to add a second apt-get update command.

Though the other OS scripts don't currently run into the same error, I thought it would be best to keep them all consistent with each other.