### PR TITLE
move rng install to after node init

### DIFF
--- a/gcp/x86_64/CentOS_7/prep/init.sh
+++ b/gcp/x86_64/CentOS_7/prep/init.sh
@@ -74,9 +74,6 @@ exec_cmd "mkdir -p $NODE_SCRIPTS_LOCATION"
 __process_msg "installing wget"
 exec_cmd "sudo yum -y install wget"
 
-__process_msg "installing rng-tools"
-exec_cmd "sudo yum -y install rng-tools"
-
 __process_msg "downloading node scripts tarball"
 exec_cmd "wget '$NODE_DOWNLOAD_URL' -O $NODE_SCRIPTS_TMP_LOC"
 
@@ -85,3 +82,6 @@ exec_cmd "tar -xzvf '$NODE_SCRIPTS_TMP_LOC' -C $NODE_SCRIPTS_LOCATION --strip-co
 
 __process_msg "Initializing node"
 source "$NODE_SCRIPTS_LOCATION/initScripts/$NODE_ARCHITECTURE/$NODE_OPERATING_SYSTEM/$INIT_SCRIPT_NAME"
+
+__process_msg "installing rng-tools"
+exec_cmd "sudo yum -y install rng-tools"

--- a/gcp/x86_64/Ubuntu_14.04/prep/init.sh
+++ b/gcp/x86_64/Ubuntu_14.04/prep/init.sh
@@ -68,9 +68,6 @@ check_envs
 __process_msg "adding dns settings to the node"
 exec_cmd "echo 'supersede domain-name-servers 8.8.8.8, 8.8.4.4;' >> /etc/dhcp/dhclient.conf"
 
-__process_msg "installing rng-tools"
-exec_cmd "apt-get install -y rng-tools"
-
 __process_msg "creating node scripts dir"
 exec_cmd "mkdir -p $NODE_SCRIPTS_LOCATION"
 
@@ -82,3 +79,6 @@ exec_cmd "tar -xzvf '$NODE_SCRIPTS_TMP_LOC' -C $NODE_SCRIPTS_LOCATION --strip-co
 
 __process_msg "Initializing node"
 source "$NODE_SCRIPTS_LOCATION/initScripts/$NODE_ARCHITECTURE/$NODE_OPERATING_SYSTEM/$INIT_SCRIPT_NAME"
+
+__process_msg "installing rng-tools"
+exec_cmd "apt-get install -y rng-tools"

--- a/gcp/x86_64/Ubuntu_16.04/prep/init.sh
+++ b/gcp/x86_64/Ubuntu_16.04/prep/init.sh
@@ -68,9 +68,6 @@ check_envs
 __process_msg "adding dns settings to the node"
 exec_cmd "echo 'supersede domain-name-servers 8.8.8.8, 8.8.4.4;' >> /etc/dhcp/dhclient.conf"
 
-__process_msg "installing rng-tools"
-exec_cmd "apt-get install -y rng-tools"
-
 __process_msg "creating node scripts dir"
 exec_cmd "mkdir -p $NODE_SCRIPTS_LOCATION"
 
@@ -82,3 +79,6 @@ exec_cmd "tar -xzvf '$NODE_SCRIPTS_TMP_LOC' -C $NODE_SCRIPTS_LOCATION --strip-co
 
 __process_msg "Initializing node"
 source "$NODE_SCRIPTS_LOCATION/initScripts/$NODE_ARCHITECTURE/$NODE_OPERATING_SYSTEM/$INIT_SCRIPT_NAME"
+
+__process_msg "installing rng-tools"
+exec_cmd "apt-get install -y rng-tools"


### PR DESCRIPTION
#683 

rng-tools will install after the node init, which should bypass the need to add an apt-get update