### PR TITLE
update for 6.12.4 release

### DIFF
--- a/images/x86_64/CentOS_7/shippable.yml
+++ b/images/x86_64/CentOS_7/shippable.yml
@@ -1270,3 +1270,34 @@ jobs:
             - popd
     on_failure:
       - script: cat /build/IN/buildami_repo/gitRepo/c7Exec/output.txt
+
+  - name: c7_v6124_update
+    type: runSh
+    dependencyMode: strict
+    triggerMode: parallel
+    steps:
+      - IN: buildami_repo
+        switch: off
+      - IN: prod_release
+        switch: off
+      - IN: baseami_params
+        switch: off
+      - IN: ami_bits_access
+        switch: off
+      - IN: execTemplates_repo_file_tag
+      - IN: node_repo_file_tag
+      - IN: cexec_repo_file_tag
+      - IN: reqExec_repo_tag
+      - IN: reqProc_repo_tag
+      - IN: c7repLib_x8664_tag
+      - IN: u14repLib_x8664_tag
+      - IN: u16repLib_x8664_tag
+      - IN: u16repLib_aarch64_tag
+      - TASK:
+          script:
+            - pushd $(shipctl get_resource_state "buildami_repo")
+            - cd c7Exec
+            - ./execPackUpdate.sh c7_v6124_update prod_release ami-0d8421c4d5b1d0522 v6124 ami_bits_access
+            - popd
+    on_failure:
+      - script: cat /build/IN/buildami_repo/gitRepo/c7Exec/output.txt

--- a/images/x86_64/Ubuntu_14.04/shippable.yml
+++ b/images/x86_64/Ubuntu_14.04/shippable.yml
@@ -2787,3 +2787,34 @@ jobs:
             - popd
     on_failure:
       - script: cat /build/IN/buildami_repo/gitRepo/exec/output.txt
+
+  - name: v6124_update
+    type: runSh
+    dependencyMode: strict
+    triggerMode: parallel
+    steps:
+      - IN: buildami_repo
+        switch: off
+      - IN: prod_release
+        switch: off
+      - IN: baseami_params
+        switch: off
+      - IN: ami_bits_access
+        switch: off
+      - IN: execTemplates_repo_file_tag
+      - IN: node_repo_file_tag
+      - IN: cexec_repo_file_tag
+      - IN: reqExec_repo_tag
+      - IN: reqProc_repo_tag
+      - IN: c7repLib_x8664_tag
+      - IN: u14repLib_x8664_tag
+      - IN: u16repLib_x8664_tag
+      - IN: u16repLib_aarch64_tag
+      - TASK:
+          script:
+            - pushd $(shipctl get_resource_state "buildami_repo")
+            - cd exec
+            - ./execPackUpdate.sh v6124_update prod_release ami-06366f3af3042f992 v6124 ami_bits_access
+            - popd
+    on_failure:
+      - script: cat /build/IN/buildami_repo/gitRepo/exec/output.txt

--- a/images/x86_64/Ubuntu_16.04/shippable.yml
+++ b/images/x86_64/Ubuntu_16.04/shippable.yml
@@ -1648,3 +1648,34 @@ jobs:
             - popd
     on_failure:
       - script: cat /build/IN/buildami_repo/gitRepo/u16Exec/output.txt
+
+  - name: u16_v6124_update
+    type: runSh
+    dependencyMode: strict
+    triggerMode: parallel
+    steps:
+      - IN: buildami_repo
+        switch: off
+      - IN: prod_release
+        switch: off
+      - IN: baseami_params
+        switch: off
+      - IN: ami_bits_access
+        switch: off
+      - IN: execTemplates_repo_file_tag
+      - IN: node_repo_file_tag
+      - IN: cexec_repo_file_tag
+      - IN: reqExec_repo_tag
+      - IN: reqProc_repo_tag
+      - IN: c7repLib_x8664_tag
+      - IN: u14repLib_x8664_tag
+      - IN: u16repLib_x8664_tag
+      - IN: u16repLib_aarch64_tag
+      - TASK:
+          script:
+            - pushd $(shipctl get_resource_state "buildami_repo")
+            - cd u16Exec
+            - ./execPackUpdate.sh u16_v6124_update prod_release ami-0391c7d542c6d374c v6124 ami_bits_access
+            - popd
+    on_failure:
+      - script: cat /build/IN/buildami_repo/gitRepo/u16Exec/output.txt

--- a/updateImages/production.csv
+++ b/updateImages/production.csv
@@ -1,4 +1,5 @@
 system_machine_image_name,builder_resource_name,prefix
+Google Cloud - Ubuntu 14.04 - v6.12.4,v6124_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v6.10.4,v6104_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v6.9.4,v694_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v6.8.4,v684_u14_x8664_gce_img,ship-bits/
@@ -11,6 +12,7 @@ Google Cloud - Ubuntu 14.04 - v6.2.4,v624_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v6.1.4,v614_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v5.10.4,v5104_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v5.8.2,v582_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 16.04 - v6.12.4,v6124_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.10.4,v6104_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.9.4,v694_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.8.4,v684_u16_x8664_gce_img,ship-bits/
@@ -19,6 +21,7 @@ Google Cloud - Ubuntu 16.04 - v6.6.4,v664_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.5.4,v654_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.4.4,v644_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.3.4,v634_u16_x8664_gce_img,ship-bits/
+Google Cloud - CentOS 7 - v6.12.4,v6124_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.10.4,v6104_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.9.4,v694_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.8.4,v684_c7_x8664_gce_img,ship-bits/
@@ -27,6 +30,7 @@ Google Cloud - CentOS 7 - v6.6.4,v664_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.5.4,v654_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.4.4,v644_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.3.4,v634_c7_x8664_gce_img,ship-bits/
+AWS - Ubuntu 14.04 - v6.12.4,v6124_update,
 AWS - Ubuntu 14.04 - v6.10.4,v6104_update,
 AWS - Ubuntu 14.04 - v6.9.4,v694_update,
 AWS - Ubuntu 14.04 - v6.8.4,v684_update,
@@ -46,6 +50,7 @@ AWS - Ubuntu 14.04 - v5.4.1,v541_update,
 AWS - Ubuntu 14.04 - v5.3.2,v532_update,
 AWS - Ubuntu 14.04 - Stable,stable_update,
 AWS - Ubuntu 14.04 - Unstable,unstable_update,
+AWS - Ubuntu 16.04 - v6.12.4,u16_v6124_update,
 AWS - Ubuntu 16.04 - v6.10.4,u16_v6104_update,
 AWS - Ubuntu 16.04 - v6.9.4,u16_v694_update,
 AWS - Ubuntu 16.04 - v6.8.4,u16_v684_update,
@@ -54,6 +59,7 @@ AWS - Ubuntu 16.04 - v6.6.4,u16_v664_update,
 AWS - Ubuntu 16.04 - v6.5.4,u16_v654_update,
 AWS - Ubuntu 16.04 - v6.4.4,u16_v644_update,
 AWS - Ubuntu 16.04 - v6.3.4,u16_v634_update,
+AWS - CentOS 7 - v6.12.4,c7_v6124_update,
 AWS - CentOS 7 - v6.10.4,c7_v6104_update,
 AWS - CentOS 7 - v6.9.4,c7_v694_update,
 AWS - CentOS 7 - v6.8.4,c7_v684_update,

--- a/updateImages/rc.csv
+++ b/updateImages/rc.csv
@@ -1,5 +1,6 @@
 system_machine_image_name,builder_resource_name,prefix
 Google Cloud - Ubuntu 14.04 - Master,patch_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v6.12.4,v6124_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v6.10.4,v6104_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v6.9.4,v694_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v6.8.4,v684_u14_x8664_gce_img,ship-bits/
@@ -13,6 +14,7 @@ Google Cloud - Ubuntu 14.04 - v6.1.4,v614_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v5.10.4,v5104_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v5.8.2,v582_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - Master,patch_u16_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 16.04 - v6.12.4,v6124_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.10.4,v6104_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.9.4,v694_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.8.4,v684_u16_x8664_gce_img,ship-bits/
@@ -22,6 +24,7 @@ Google Cloud - Ubuntu 16.04 - v6.5.4,v654_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.4.4,v644_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.3.4,v634_u16_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - Master,patch_c7_x8664_gce_img,ship-bits/
+Google Cloud - CentOS 7 - v6.12.4,v6124_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.10.4,v6104_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.9.4,v694_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.8.4,v684_c7_x8664_gce_img,ship-bits/
@@ -30,6 +33,7 @@ Google Cloud - CentOS 7 - v6.6.4,v664_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.5.4,v654_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.4.4,v644_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.3.4,v634_c7_x8664_gce_img,ship-bits/
+AWS - Ubuntu 14.04 - v6.12.4,v6124_update,
 AWS - Ubuntu 14.04 - v6.10.4,v6104_update,
 AWS - Ubuntu 14.04 - v6.9.4,v694_update,
 AWS - Ubuntu 14.04 - v6.8.4,v684_update,
@@ -47,6 +51,7 @@ AWS - Ubuntu 14.04 - v5.6.1,v561_update,
 AWS - Ubuntu 14.04 - v5.5.1,v551_update,
 AWS - Ubuntu 14.04 - v5.4.1,v541_update,
 AWS - Ubuntu 14.04 - v5.3.2,v532_update,
+AWS - Ubuntu 16.04 - v6.12.4,u16_v6124_update,
 AWS - Ubuntu 16.04 - v6.10.4,u16_v6104_update,
 AWS - Ubuntu 16.04 - v6.9.4,u16_v694_update,
 AWS - Ubuntu 16.04 - v6.8.4,u16_v684_update,
@@ -55,6 +60,7 @@ AWS - Ubuntu 16.04 - v6.6.4,u16_v664_update,
 AWS - Ubuntu 16.04 - v6.5.4,u16_v654_update,
 AWS - Ubuntu 16.04 - v6.4.4,u16_v644_update,
 AWS - Ubuntu 16.04 - v6.3.4,u16_v634_update,
+AWS - CentOS 7 - v6.12.4,c7_v6124_update,
 AWS - CentOS 7 - v6.10.4,c7_v6104_update,
 AWS - CentOS 7 - v6.9.4,c7_v694_update,
 AWS - CentOS 7 - v6.8.4,c7_v684_update,


### PR DESCRIPTION
https://github.com/Shippable/pm/issues/11629

adds update jobs for the newest AMIs, also updates the CSVs so that the SMI update automation job can be used.