### PR TITLE
removing centos base image dependency on prod_release

### DIFF
--- a/images/x86_64/CentOS_7/shippable.yml
+++ b/images/x86_64/CentOS_7/shippable.yml
@@ -449,7 +449,6 @@ jobs:
     integrations:
       - ship_ssh
     steps:
-      - IN: prod_release
       - IN: drydock_release
       - IN: c7_dd_repo
         switch: off


### PR DESCRIPTION
- https://github.com/Shippable/buildami/issues/698