### PR TITLE
add update jobs for 7.2.4

### DIFF
--- a/images/x86_64/CentOS_7/shippable.yml
+++ b/images/x86_64/CentOS_7/shippable.yml
@@ -1830,3 +1830,34 @@ jobs:
             - popd
     on_failure:
       - script: cat /build/IN/buildami_repo/gitRepo/c7Exec/output.txt
+
+  - name: c7_v724_update
+    type: runSh
+    dependencyMode: strict
+    triggerMode: parallel
+    steps:
+      - IN: buildami_repo
+        switch: off
+      - IN: prod_release
+        switch: off
+      - IN: baseami_params
+        switch: off
+      - IN: ami_bits_access
+        switch: off
+      - IN: execTemplates_repo_file_tag
+      - IN: node_repo_file_tag
+      - IN: cexec_repo_file_tag
+      - IN: reqExec_repo_tag
+      - IN: reqProc_repo_tag
+      - IN: c7repLib_x8664_tag
+      - IN: u14repLib_x8664_tag
+      - IN: u16repLib_x8664_tag
+      - IN: u16repLib_aarch64_tag
+      - TASK:
+          script:
+            - pushd $(shipctl get_resource_state "buildami_repo")
+            - cd c7Exec
+            - ./execPackUpdate.sh c7_v724_update prod_release ami-004f08630d5eb1636 v724 ami_bits_access
+            - popd
+    on_failure:
+      - script: cat /build/IN/buildami_repo/gitRepo/c7Exec/output.txt

--- a/images/x86_64/Ubuntu_14.04/shippable.yml
+++ b/images/x86_64/Ubuntu_14.04/shippable.yml
@@ -3015,3 +3015,34 @@ jobs:
             - popd
     on_failure:
       - script: cat /build/IN/buildami_repo/gitRepo/exec/output.txt
+
+  - name: v724_update
+    type: runSh
+    dependencyMode: strict
+    triggerMode: parallel
+    steps:
+      - IN: buildami_repo
+        switch: off
+      - IN: prod_release
+        switch: off
+      - IN: baseami_params
+        switch: off
+      - IN: ami_bits_access
+        switch: off
+      - IN: execTemplates_repo_file_tag
+      - IN: node_repo_file_tag
+      - IN: cexec_repo_file_tag
+      - IN: reqExec_repo_tag
+      - IN: reqProc_repo_tag
+      - IN: c7repLib_x8664_tag
+      - IN: u14repLib_x8664_tag
+      - IN: u16repLib_x8664_tag
+      - IN: u16repLib_aarch64_tag
+      - TASK:
+          script:
+            - pushd $(shipctl get_resource_state "buildami_repo")
+            - cd exec
+            - ./execPackUpdate.sh v724_update prod_release ami-0fedfbf64cb4ccb5e v724 ami_bits_access
+            - popd
+    on_failure:
+      - script: cat /build/IN/buildami_repo/gitRepo/exec/output.txt

--- a/images/x86_64/Ubuntu_16.04/shippable.yml
+++ b/images/x86_64/Ubuntu_16.04/shippable.yml
@@ -1867,3 +1867,34 @@ jobs:
             - popd
     on_failure:
       - script: cat /build/IN/buildami_repo/gitRepo/u16Exec/output.txt
+
+  - name: u16_v724_update
+    type: runSh
+    dependencyMode: strict
+    triggerMode: parallel
+    steps:
+      - IN: buildami_repo
+        switch: off
+      - IN: prod_release
+        switch: off
+      - IN: baseami_params
+        switch: off
+      - IN: ami_bits_access
+        switch: off
+      - IN: execTemplates_repo_file_tag
+      - IN: node_repo_file_tag
+      - IN: cexec_repo_file_tag
+      - IN: reqExec_repo_tag
+      - IN: reqProc_repo_tag
+      - IN: c7repLib_x8664_tag
+      - IN: u14repLib_x8664_tag
+      - IN: u16repLib_x8664_tag
+      - IN: u16repLib_aarch64_tag
+      - TASK:
+          script:
+            - pushd $(shipctl get_resource_state "buildami_repo")
+            - cd u16Exec
+            - ./execPackUpdate.sh u16_v724_update prod_release ami-0c5e425aeb5f04646 v724 ami_bits_access
+            - popd
+    on_failure:
+      - script: cat /build/IN/buildami_repo/gitRepo/u16Exec/output.txt

--- a/images/x86_64/WindowsServer_2016/shippable.yml
+++ b/images/x86_64/WindowsServer_2016/shippable.yml
@@ -989,3 +989,59 @@ jobs:
         - shipctl put_resource_state_multi $env:JOB_NAME "updateAmiId=$env:UPDATE_AMI_ID"
     on_failure:
       - script: cat /build/IN/buildami_repo/gitRepo/windowsExec/output.txt
+
+  - name: v724_w2k16_aws
+    type: runSh
+    dependencyMode: strict
+    triggerMode: parallel
+    runtime:
+      nodePool: w2k16_cache
+    steps:
+      - IN: buildami_repo
+        switch: off
+      - IN: windowsbaseami_params
+        switch: off
+      - IN: windowsbaseami_winrm_keys
+        switch: off
+      - IN: prod_release
+        switch: off
+      - IN: ami_bits_access_cli
+        switch: off
+      - IN: node_repo_file_tag
+      - IN: reqKick_repo_file_tag
+      - IN: w2k16reqProc_dd_tag
+      - TASK:
+          runtime:
+              options:
+                imageName: drydock/w16
+                imageTag: v7.2.4
+                env:
+                  - UPDATE_AMI_ID: ami-0dec38e65426383e5
+                  - UPDATE_AMI_VERSION: v7.2.4
+                  - AMI_TYPE: v724
+          script:
+            - pushd "$(shipctl get_resource_state "buildami_repo")/windowsExec"
+            - $env:AWS_ACCESS_KEY_ID = $(shipctl get_integration_resource_field ami_bits_access_cli "accessKey")
+            - $env:AWS_SECRET_ACCESS_KEY = $(shipctl get_integration_resource_field ami_bits_access_cli "secretKey")
+            - $env:AMI_ID = $env:UPDATE_AMI_ID
+            - $env:REL_VER = $(shipctl get_resource_version_name prod_release)
+            - $env:REL_DASH_VER = ($env:REL_VER).replace(".", "-")
+            - shipctl replace bootstrap_win_update.txt vars.json
+            - |
+              $vars_content = Get-Content .\vars.json
+              $vars_path = (Get-ChildItem .\vars.json).FullName
+              [IO.File]::WriteAllLines($vars_path, $vars_content)
+            - |
+              $bootstrap_content = get-content .\bootstrap_win_update.txt
+              $bootstrap_path = (Get-ChildItem .\bootstrap_win_update.txt).FullName
+              [IO.File]::WriteAllLines($bootstrap_path, $bootstrap_content)
+            - packer validate -var-file="vars.json" execAMIUpdate.json
+            - packer build -machine-readable -var-file="vars.json" execAMIUpdate.json 2>&1 | tee-object output.txt
+            - $env:IMAGE_NAME=$(Get-content .\output.txt | where-object { $_ -match "artifact,0,id" } | foreach-object { (($_ -split ",")[5] -split ':')[1] })
+            - popd
+    on_success:
+      script:
+        - shipctl put_resource_state_multi $env:JOB_NAME "versionName=$env:IMAGE_NAME"
+        - shipctl put_resource_state_multi $env:JOB_NAME "updateAmiId=$env:UPDATE_AMI_ID"
+    on_failure:
+      - script: cat /build/IN/buildami_repo/gitRepo/windowsExec/output.txt

--- a/updateImages/production.csv
+++ b/updateImages/production.csv
@@ -1,4 +1,5 @@
 system_machine_image_name,builder_resource_name,prefix
+Google Cloud - Ubuntu 14.04 - v7.2.4,v724_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v7.1.4,v714_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v6.12.4,v6124_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v6.10.4,v6104_u14_x8664_gce_img,ship-bits/
@@ -13,6 +14,7 @@ Google Cloud - Ubuntu 14.04 - v6.2.4,v624_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v6.1.4,v614_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v5.10.4,v5104_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v5.8.2,v582_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 16.04 - v7.2.4,v724_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v7.1.4,v714_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.12.4,v6124_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.10.4,v6104_u16_x8664_gce_img,ship-bits/
@@ -23,6 +25,7 @@ Google Cloud - Ubuntu 16.04 - v6.6.4,v664_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.5.4,v654_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.4.4,v644_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.3.4,v634_u16_x8664_gce_img,ship-bits/
+Google Cloud - CentOS 7 - v7.2.4,v724_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v7.1.4,v714_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.12.4,v6124_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.10.4,v6104_c7_x8664_gce_img,ship-bits/
@@ -33,6 +36,7 @@ Google Cloud - CentOS 7 - v6.6.4,v664_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.5.4,v654_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.4.4,v644_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.3.4,v634_c7_x8664_gce_img,ship-bits/
+AWS - Ubuntu 14.04 - v7.2.4,v724_update,
 AWS - Ubuntu 14.04 - v7.1.4,v714_update,
 AWS - Ubuntu 14.04 - v6.12.4,v6124_update,
 AWS - Ubuntu 14.04 - v6.10.4,v6104_update,
@@ -54,6 +58,7 @@ AWS - Ubuntu 14.04 - v5.4.1,v541_update,
 AWS - Ubuntu 14.04 - v5.3.2,v532_update,
 AWS - Ubuntu 14.04 - Stable,stable_update,
 AWS - Ubuntu 14.04 - Unstable,unstable_update,
+AWS - Ubuntu 16.04 - v7.2.4,u16_v724_update,
 AWS - Ubuntu 16.04 - v7.1.4,u16_v714_update,
 AWS - Ubuntu 16.04 - v6.12.4,u16_v6124_update,
 AWS - Ubuntu 16.04 - v6.10.4,u16_v6104_update,
@@ -64,6 +69,7 @@ AWS - Ubuntu 16.04 - v6.6.4,u16_v664_update,
 AWS - Ubuntu 16.04 - v6.5.4,u16_v654_update,
 AWS - Ubuntu 16.04 - v6.4.4,u16_v644_update,
 AWS - Ubuntu 16.04 - v6.3.4,u16_v634_update,
+AWS - CentOS 7 - v7.2.4,c7_v724_update,
 AWS - CentOS 7 - v7.1.4,c7_v714_update,
 AWS - CentOS 7 - v6.12.4,c7_v6124_update,
 AWS - CentOS 7 - v6.10.4,c7_v6104_update,
@@ -74,3 +80,14 @@ AWS - CentOS 7 - v6.6.4,c7_v664_update,
 AWS - CentOS 7 - v6.5.4,c7_v654_update,
 AWS - CentOS 7 - v6.4.4,c7_v644_update,
 AWS - CentOS 7 - v6.3.4,c7_v634_update,
+AWS - Windows Server 2016 - v7.2.4,v724_w2k16_aws,
+AWS - Windows Server 2016 - v7.1.4,v714_w2k16_aws,
+AWS - Windows Server 2016 - v6.12.4,v6124_w2k16_aws,
+AWS - Windows Server 2016 - v6.10.4,v6104_w2k16_aws,
+AWS - Windows Server 2016 - v6.9.4,v694_w2k16_aws,
+AWS - Windows Server 2016 - v6.8.4,v684_w2k16_aws,
+AWS - Windows Server 2016 - v6.7.4,v674_w2k16_aws,
+AWS - Windows Server 2016 - v6.6.4,v664_w2k16_aws,
+AWS - Windows Server 2016 - v6.5.4,v654_w2k16_aws,
+AWS - Windows Server 2016 - v6.4.4,v644_w2k16_aws,
+AWS - Windows Server 2016 - v6.3.4,v634_w2k16_aws,

--- a/updateImages/rc.csv
+++ b/updateImages/rc.csv
@@ -1,5 +1,6 @@
 system_machine_image_name,builder_resource_name,prefix
 Google Cloud - Ubuntu 14.04 - Master,patch_u14_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 14.04 - v7.2.4,v724_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v7.1.4,v714_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v6.12.4,v6124_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v6.10.4,v6104_u14_x8664_gce_img,ship-bits/
@@ -15,6 +16,7 @@ Google Cloud - Ubuntu 14.04 - v6.1.4,v614_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v5.10.4,v5104_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 14.04 - v5.8.2,v582_u14_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - Master,patch_u16_x8664_gce_img,ship-bits/
+Google Cloud - Ubuntu 16.04 - v7.2.4,v724_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v7.1.4,v714_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.12.4,v6124_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.10.4,v6104_u16_x8664_gce_img,ship-bits/
@@ -26,6 +28,7 @@ Google Cloud - Ubuntu 16.04 - v6.5.4,v654_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.4.4,v644_u16_x8664_gce_img,ship-bits/
 Google Cloud - Ubuntu 16.04 - v6.3.4,v634_u16_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - Master,patch_c7_x8664_gce_img,ship-bits/
+Google Cloud - CentOS 7 - v7.2.4,v724_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v7.1.4,v714_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.12.4,v6124_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.10.4,v6104_c7_x8664_gce_img,ship-bits/
@@ -36,6 +39,7 @@ Google Cloud - CentOS 7 - v6.6.4,v664_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.5.4,v654_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.4.4,v644_c7_x8664_gce_img,ship-bits/
 Google Cloud - CentOS 7 - v6.3.4,v634_c7_x8664_gce_img,ship-bits/
+AWS - Ubuntu 14.04 - v7.2.4,v724_update,
 AWS - Ubuntu 14.04 - v7.1.4,v714_update,
 AWS - Ubuntu 14.04 - v6.12.4,v6124_update,
 AWS - Ubuntu 14.04 - v6.10.4,v6104_update,
@@ -55,6 +59,7 @@ AWS - Ubuntu 14.04 - v5.6.1,v561_update,
 AWS - Ubuntu 14.04 - v5.5.1,v551_update,
 AWS - Ubuntu 14.04 - v5.4.1,v541_update,
 AWS - Ubuntu 14.04 - v5.3.2,v532_update,
+AWS - Ubuntu 16.04 - v7.2.4,u16_v724_update,
 AWS - Ubuntu 16.04 - v7.1.4,u16_v714_update,
 AWS - Ubuntu 16.04 - v6.12.4,u16_v6124_update,
 AWS - Ubuntu 16.04 - v6.10.4,u16_v6104_update,
@@ -65,6 +70,7 @@ AWS - Ubuntu 16.04 - v6.6.4,u16_v664_update,
 AWS - Ubuntu 16.04 - v6.5.4,u16_v654_update,
 AWS - Ubuntu 16.04 - v6.4.4,u16_v644_update,
 AWS - Ubuntu 16.04 - v6.3.4,u16_v634_update,
+AWS - CentOS 7 - v7.2.4,c7_v724_update,
 AWS - CentOS 7 - v7.1.4,c7_v714_update,
 AWS - CentOS 7 - v6.12.4,c7_v6124_update,
 AWS - CentOS 7 - v6.10.4,c7_v6104_update,
@@ -75,3 +81,14 @@ AWS - CentOS 7 - v6.6.4,c7_v664_update,
 AWS - CentOS 7 - v6.5.4,c7_v654_update,
 AWS - CentOS 7 - v6.4.4,c7_v644_update,
 AWS - CentOS 7 - v6.3.4,c7_v634_update,
+AWS - Windows Server 2016 - v7.2.4,v724_w2k16_aws,
+AWS - Windows Server 2016 - v7.1.4,v714_w2k16_aws,
+AWS - Windows Server 2016 - v6.12.4,v6124_w2k16_aws,
+AWS - Windows Server 2016 - v6.10.4,v6104_w2k16_aws,
+AWS - Windows Server 2016 - v6.9.4,v694_w2k16_aws,
+AWS - Windows Server 2016 - v6.8.4,v684_w2k16_aws,
+AWS - Windows Server 2016 - v6.7.4,v674_w2k16_aws,
+AWS - Windows Server 2016 - v6.6.4,v664_w2k16_aws,
+AWS - Windows Server 2016 - v6.5.4,v654_w2k16_aws,
+AWS - Windows Server 2016 - v6.4.4,v644_w2k16_aws,
+AWS - Windows Server 2016 - v6.3.4,v634_w2k16_aws,


### PR DESCRIPTION
https://github.com/Shippable/pm/issues/11831

- adds `update` jobs for aws 7.2.4 release to the pipeline
- adds 7.2.4 lines to the machine image auto-update script
- adds windows jobs to the machine image auto-update script